### PR TITLE
Update LandingPage.js

### DIFF
--- a/MobileGainBoy/MobileGainBoy/src/LandingPage.js
+++ b/MobileGainBoy/MobileGainBoy/src/LandingPage.js
@@ -1,15 +1,22 @@
-import React from 'react';
-import {
-    Text, 
-    View,
-} from 'react-native';
+import React from "react";
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View, Button } from 'react-native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import Tabs from '../navigation/tabs';
 
-function LandingPage(){
-    return(
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-            <Text>Landing Screen</Text>
-        </View>
+const LandingScreen = ({ navigation }) => {
+    return (
+        <Tabs />
     );
 }
 
-export default LandingPage;
+export default LandingScreen;
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: "#8fcbbc",
+    }
+})


### PR DESCRIPTION
Added a bottom tab menu that lets you navigate between 3 pages: Profile, Workout, Logs/History. The Landing screen now opens up to start on the Workout page and you can navigate between the rest from there.